### PR TITLE
fix: USB stability improvements (#13) and universal DIO build (#22)

### DIFF
--- a/lib/NUTServer/src/NUTServer.cpp
+++ b/lib/NUTServer/src/NUTServer.cpp
@@ -279,6 +279,7 @@ void NUTServer::handleCommand(int slot, const String& cmdLine) {
                 if (data.timerStart >= 0) client.printf("VAR %s ups.timer.start \"%d\"\n", upsName.c_str(), data.timerStart);
                 if (data.timerShutdown >= 0) client.printf("VAR %s ups.timer.shutdown \"%d\"\n", upsName.c_str(), data.timerShutdown);
                 if (data.batteryType.length() > 0) client.printf("VAR %s battery.type \"%s\"\n", upsName.c_str(), data.batteryType.c_str());
+                if (data.batteryMfrDate.length() > 0) client.printf("VAR %s battery.mfr.date \"%s\"\n", upsName.c_str(), data.batteryMfrDate.c_str());
                 if (data.upsType.length() > 0) client.printf("VAR %s ups.type \"%s\"\n", upsName.c_str(), data.upsType.c_str());
                 client.printf("VAR %s ups.beeper.status \"%s\"\n", upsName.c_str(), data.beeperEnabled ? "enabled" : "disabled");
                 client.printf("VAR %s outlet.1.switch \"%d\"\n", upsName.c_str(), data.outlet1Switch ? 1 : 0);
@@ -458,6 +459,8 @@ void NUTServer::handleCommand(int slot, const String& cmdLine) {
                 client.printf("VAR %s ups.timer.shutdown \"%d\"\n", upsName.c_str(), data.timerShutdown);
             } else if (varNameLower == "battery.type" && data.batteryType.length() > 0) {
                 client.printf("VAR %s battery.type \"%s\"\n", upsName.c_str(), data.batteryType.c_str());
+            } else if (varNameLower == "battery.mfr.date" && data.batteryMfrDate.length() > 0) {
+                client.printf("VAR %s battery.mfr.date \"%s\"\n", upsName.c_str(), data.batteryMfrDate.c_str());
             } else if (varNameLower == "ups.type" && data.upsType.length() > 0) {
                 client.printf("VAR %s ups.type \"%s\"\n", upsName.c_str(), data.upsType.c_str());
             } else if (varNameLower == "ups.beeper.status") {

--- a/lib/USBHostUPS/src/APCDriver.cpp
+++ b/lib/USBHostUPS/src/APCDriver.cpp
@@ -3,7 +3,7 @@
 #include "HIDUsages.h"
 #include <string.h>
 
-APCDriver::APCDriver() : _poll_step(0), _last_step_time(0), _last_fast_poll(0), _slow_poll_counter(0), _last_poll(0) {}
+APCDriver::APCDriver() : _poll_step(0), _last_step_time(0), _last_fast_poll(0), _slow_poll_counter(0), _last_poll(0), _batteryDateStringIndex(0) {}
 
 
 void APCDriver::setup() {
@@ -41,6 +41,8 @@ void APCDriver::loop(USBHostUPS* host, UPSData& data, uint32_t now) {
                 if (_slow_poll_counter == 0 && data.product == "") if (host->_iProduct > 0) host->requestStringDescriptor(host->_iProduct);
             } else if (_poll_step == 3) {
                 if (_slow_poll_counter == 0 && data.serialNumber == "") if (host->_iSerialNumber > 0) host->requestStringDescriptor(host->_iSerialNumber);
+            } else if (_poll_step == 4) {
+                if (_slow_poll_counter == 0 && data.batteryMfrDate == "" && _batteryDateStringIndex > 0) host->requestStringDescriptor(_batteryDateStringIndex);
             } else {
                 const auto& usages = host->_hid_parser.getUsages();
                 std::vector<uint16_t> rids;
@@ -69,7 +71,7 @@ void APCDriver::loop(USBHostUPS* host, UPSData& data, uint32_t now) {
                     ++it;
                 }
                 
-                int index = _poll_step - 4;
+                int index = _poll_step - 5;
                 if (index >= 0 && index < rids.size()) {
                     uint8_t r_type = rids[index] >> 8;
                     uint8_t r_id = rids[index] & 0xFF;
@@ -115,6 +117,12 @@ void APCDriver::decodeReport(USBHostUPS* host, uint8_t report_id, uint8_t report
         }},
         { "UPS.Battery.Temperature", [](APCDriver*, UPSData& d, double v, const HIDUsageDef*) {
             d.batteryTemperature = (v > 200.0) ? (v - 273.15) : v;
+        }},
+        { "UPS.BatterySystem.Battery.Date", [](APCDriver* drv, UPSData& d, double v, const HIDUsageDef* def) {
+            if (def && v > 0) drv->_batteryDateStringIndex = (uint8_t)v;
+        }},
+        { "UPS.Battery.Date", [](APCDriver* drv, UPSData& d, double v, const HIDUsageDef* def) {
+            if (def && v > 0) drv->_batteryDateStringIndex = (uint8_t)v;
         }},
         { "UPS.Output.PercentLoad", [](APCDriver*, UPSData& d, double v, const HIDUsageDef*) {
             d.load = (uint8_t)v;
@@ -202,5 +210,6 @@ void APCDriver::parseStringDescriptor(USBHostUPS* host, uint8_t index, const uin
     if (index == host->_iManufacturer) ups_data.manufacturer = str;
     else if (index == host->_iProduct) ups_data.product = str;
     else if (index == host->_iSerialNumber) ups_data.serialNumber = str;
+    else if (_batteryDateStringIndex > 0 && index == _batteryDateStringIndex) ups_data.batteryMfrDate = str;
 }
 

--- a/lib/USBHostUPS/src/APCDriver.h
+++ b/lib/USBHostUPS/src/APCDriver.h
@@ -21,6 +21,7 @@ private:
     uint8_t _poll_step;
     uint8_t _slow_poll_counter;
     String _active_beeper;
+    uint8_t _batteryDateStringIndex;
 };
 
 #endif // APC_DRIVER_H

--- a/lib/USBHostUPS/src/GenericDriver.cpp
+++ b/lib/USBHostUPS/src/GenericDriver.cpp
@@ -49,6 +49,8 @@ void GenericDriver::loop(USBHostUPS* host, UPSData& data, uint32_t now) {
                 if (_slow_poll_counter == 0 && data.product == "") if (host->_iProduct > 0) host->requestStringDescriptor(host->_iProduct);
             } else if (_poll_step == 3) {
                 if (_slow_poll_counter == 0 && data.serialNumber == "") if (host->_iSerialNumber > 0) host->requestStringDescriptor(host->_iSerialNumber);
+            } else if (_poll_step == 4) {
+                if (_slow_poll_counter == 0 && data.batteryMfrDate == "" && _batteryDateStringIndex > 0) host->requestStringDescriptor(_batteryDateStringIndex);
             } else {
                 const auto& usages = host->_hid_parser.getUsages();
                 std::vector<uint16_t> rids;
@@ -76,7 +78,7 @@ void GenericDriver::loop(USBHostUPS* host, UPSData& data, uint32_t now) {
                     ++it;
                 }
                 
-                int index = _poll_step - 4;
+                int index = _poll_step - 5;
                 if (index >= 0 && index < rids.size()) {
                     uint8_t r_type = rids[index] >> 8;
                     uint8_t r_id = rids[index] & 0xFF;
@@ -137,6 +139,12 @@ void GenericDriver::decodeReport(USBHostUPS* host, uint8_t report_id, uint8_t re
             d.load = (uint8_t)v;
             if (d.configActivePower > 0) d.realPower = (uint16_t)(((uint32_t)d.configActivePower * (uint32_t)v) / 100);
             else if (d.configApparentPower > 0) d.realPower = (uint16_t)(((uint32_t)d.configApparentPower * 60 * (uint32_t)v) / 10000);
+        }},
+        { "UPS.BatterySystem.Battery.Date", [](GenericDriver* drv, UPSData& d, double v, const HIDUsageDef* def) {
+            if (def && v > 0) drv->_batteryDateStringIndex = (uint8_t)v;
+        }},
+        { "UPS.Battery.Date", [](GenericDriver* drv, UPSData& d, double v, const HIDUsageDef* def) {
+            if (def && v > 0) drv->_batteryDateStringIndex = (uint8_t)v;
         }},
         { "UPS.Battery.Temperature", [](GenericDriver*, UPSData& d, double v, const HIDUsageDef*) {
             d.batteryTemperature = (v > 200.0) ? (v - 273.15) : v;
@@ -229,6 +237,7 @@ void GenericDriver::parseStringDescriptor(USBHostUPS* host, uint8_t index, const
     }
     if (index == host->_iManufacturer) ups_data.manufacturer = str;
     else if (index == host->_iProduct) ups_data.product = str;
-    else if (host->_iSerialNumber > 0 && index == host->_iSerialNumber) ups_data.serialNumber = str;
+    else if (index == host->_iSerialNumber) ups_data.serialNumber = str;
+    else if (_batteryDateStringIndex > 0 && index == _batteryDateStringIndex) ups_data.batteryMfrDate = str;
 }
 

--- a/lib/USBHostUPS/src/GenericDriver.h
+++ b/lib/USBHostUPS/src/GenericDriver.h
@@ -21,6 +21,7 @@ private:
     uint8_t _poll_step;
     uint8_t _slow_poll_counter;
     String _active_beeper;
+    uint8_t _batteryDateStringIndex;
 };
 
 #endif // GENERIC_DRIVER_H

--- a/lib/USBHostUPS/src/USBHostUPS.cpp
+++ b/lib/USBHostUPS/src/USBHostUPS.cpp
@@ -553,8 +553,10 @@ void USBHostUPS::loop() {
 bool USBHostUPS::requestReport(uint8_t report_id, uint8_t report_type, uint16_t expected_length) {
     if (_dev_handle == NULL) return false;
 
+    // Allocate 255 bytes for data to avoid HCD asserts if device sends more bytes or rounds to MPS
+    uint16_t alloc_length = 255;
     usb_transfer_t *transfer = NULL;
-    esp_err_t err = usb_host_transfer_alloc(8 + expected_length, 0, &transfer);
+    esp_err_t err = usb_host_transfer_alloc(8 + alloc_length, 0, &transfer);
     if (err != ESP_OK) {
         return false;
     }
@@ -569,7 +571,7 @@ bool USBHostUPS::requestReport(uint8_t report_id, uint8_t report_type, uint16_t 
     transfer->device_handle = _dev_handle;
     transfer->callback = control_transfer_cb;
     transfer->context = this;
-    transfer->num_bytes = 8 + expected_length;
+    transfer->num_bytes = 8 + alloc_length;
 
     err = usb_host_transfer_submit_control(_client_handle, transfer);
     if (err != ESP_OK) {

--- a/lib/USBHostUPS/src/USBHostUPS.h
+++ b/lib/USBHostUPS/src/USBHostUPS.h
@@ -48,6 +48,7 @@ struct UPSData {
     String manufacturer = "";
     String product = "";
     String serialNumber = "";
+    String batteryMfrDate = "";
 
     uint8_t load = 0;
     uint16_t realPower = 0;

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32.git#51.03.04
 board = esp32-s3-devkitc-1
 framework = arduino
 board_build.partitions = partitions.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,15 +1,27 @@
-[env:esp32-s3-devkitc-1]
-platform = https://github.com/pioarduino/platform-espressif32.git#51.03.04
-board = esp32-s3-devkitc-1
+; Impostazioni condivise per tutti i firmware ESP32
+[env]
 framework = arduino
-board_build.partitions = partitions.csv
-extra_scripts = pre:scripts/embed_web.py
 monitor_speed = 115200
-test_build_src = true
+extra_scripts = pre:scripts/embed_web.py
 lib_deps =
     bblanchon/ArduinoJson@^7.0.0
     adafruit/Adafruit NeoPixel@^1.12.0
 
+; ---------------------------------------------------------
+; 1. Environment per Firmware ESP32-S3 (Universal 8MB DIO)
+; ---------------------------------------------------------
+[env:esp32-s3-standard]
+platform = https://github.com/pioarduino/platform-espressif32.git#51.03.04
+board = esp32-s3-devkitc-1
+board_build.flash_mode = dio
+board_build.flash_size = 8MB
+board_build.partitions = partitions.csv
+board_build.f_flash = 80000000L
+test_build_src = true
+
+; ---------------------------------------------------------
+; 3. Environment per i Test (Native)
+; ---------------------------------------------------------
 [env:native]
 platform = native
 test_ignore = test_eaton_driver, test_diagnostic_led, test_network_manager, test_nut_server, test_ota_handler, test_system_state, test_usb_host, test_web_api, integration, test_config_manager

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -82,6 +82,14 @@ void setup() {
         usb_ups.setLogCallback([](const char* level, const char* msg) {
             AppLogger::log(level, msg);
         });
+
+        // Delay USB host initialization on cold boot to allow the UPS USB interface to stabilize
+        // Many UPS devices (like APC) take a few seconds to properly handle USB requests after power on.
+        uint32_t wait_until = 3000;
+        while (millis() < wait_until) {
+            delay(10);
+        }
+
         if (!usb_ups.begin()) {
             AppLogger::log("ERROR", "[MAIN] ERROR: USBHostUPS initialization failed!");
         } else {

--- a/test/test_ota_handler/test_main.cpp
+++ b/test/test_ota_handler/test_main.cpp
@@ -3,7 +3,7 @@
 void setUp(void) {}  
 void tearDown(void) {}  
 void test_ota_magic_byte_valid() { uint8_t magic_byte = 0xE9; TEST_ASSERT_EQUAL_HEX8(0xE9, magic_byte); }  
-void test_ota_magic_byte_invalid() { uint8_t invalid_byte = 0x00; TEST_ASSERT_NOT_EQUAL_HEX8(0xE9, invalid_byte); }  
+void test_ota_magic_byte_invalid() { uint8_t invalid_byte = 0x00; TEST_ASSERT_NOT_EQUAL(0xE9, invalid_byte); }  
 void test_ota_upload_empty() { int totalSize = 0; TEST_ASSERT_EQUAL(0, totalSize); }  
 void setup() { delay(2000); UNITY_BEGIN(); RUN_TEST(test_ota_magic_byte_valid); RUN_TEST(test_ota_magic_byte_invalid); RUN_TEST(test_ota_upload_empty); UNITY_END(); }  
 void loop() { delay(100); } 


### PR DESCRIPTION
**Resolves:** #13, #22 

**Overview:**
This PR bundles two related branches into `main`, bringing major improvements to both USB framework stability and hardware board compatibility.

**1. Core Framework & USB Stability (Resolves #13)**
- **Platform Update:** Upgraded platform to `pioarduino` 51.03.04 (ESP-IDF 5.1.4) and fixed associated test compilation errors.
- **HCD Assertion Fix:** Allocated 255 bytes for USB control transfers to prevent memory corruption and HCD assertions.
- **Device Initialization:** Added a delay on boot to prevent STALL errors during the initial USB handshake (significantly improving stability with APC units) and added mapping for `battery.mfr.date`.

**2. Hardware Flash Compatibility (Resolves #22)**
- **Bootloop Fix:** Generic ESP32-S3 boards (typically 8MB) often wire their flash using Dual-SPI (`dio`) instead of Quad-SPI (`qio`). Defaulting to QIO caused infinite bootloops on these clones.
- **Universal Environment:** Refactored `platformio.ini` to consolidate the ESP32-S3 target into a single "Universal 8MB DIO" build. 
- **Impact:** The firmware will now safely install via Web Serial and boot on *any* ESP32-S3 board (official DevKits or clones) without requiring users to guess their flash layout. The switch to DIO has zero practical impact on the application's overall performance.
