### PR TITLE
fix(nut): implement the commands standard NUT clients require

### DIFF
--- a/lib/NUTServer/src/NUTServer.cpp
+++ b/lib/NUTServer/src/NUTServer.cpp
@@ -1,5 +1,17 @@
 #include "NUTServer.h"
 
+// Shared by LIST UPS and GET UPSDESC so the two cannot drift.
+static const char* NUT_UPS_DESCRIPTION = "ESP32-S3 UPS Bridge";
+
+// Injected at build time from the release tag; "dev" for local builds, matching
+// src/network/web_config_server.cpp.
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "dev"
+#endif
+
+// Protocol level the implemented command subset targets, as upsd reports it.
+static const char* NUT_PROTOCOL_VERSION = "1.3";
+
 NUTServer::NUTServer() : 
     _usb_ups(nullptr), 
     _port(NUT_DEFAULT_PORT), 
@@ -175,6 +187,16 @@ void NUTServer::processCommand(Print& client, int slot, const String& cmdLine) {
 
     bool authRequired = (_config.username.length() > 0 && _config.password.length() > 0);
 
+    if (cmd == "VER") {
+        client.printf("Network UPS Tools esp32-nut %s\n", FIRMWARE_VERSION);
+        return;
+    }
+
+    if (cmd == "NETVER") {
+        client.printf("%s\n", NUT_PROTOCOL_VERSION);
+        return;
+    }
+
     if (cmd == "USERNAME") {
         if (tokens.size() < 2) {
             client.print("ERR INVALID-ARGUMENT\n");
@@ -241,7 +263,7 @@ void NUTServer::processCommand(Print& client, int slot, const String& cmdLine) {
 
         if (subcmd == "UPS") {
             client.print("BEGIN LIST UPS\n");
-            client.printf("UPS %s \"ESP32-S3 UPS Bridge\"\n", _config.ups_name.c_str());
+            client.printf("UPS %s \"%s\"\n", _config.ups_name.c_str(), NUT_UPS_DESCRIPTION);
             client.print("END LIST UPS\n");
             return;
         } 
@@ -303,7 +325,7 @@ void NUTServer::processCommand(Print& client, int slot, const String& cmdLine) {
             client.printf("END LIST VAR %s\n", upsName.c_str());
             return;
         }
-        else if (subcmd == "CMD" || subcmd == "RW") {
+        else if (subcmd == "CMD" || subcmd == "RW" || subcmd == "CLIENT") {
             String upsName;
             if (tokens.size() < 3) {
                 upsName = _config.ups_name;
@@ -506,6 +528,69 @@ void NUTServer::processCommand(Print& client, int slot, const String& cmdLine) {
                 client.printf("VAR %s outlet.2.switch \"%d\"\n", upsName.c_str(), data.outlet2Switch ? 1 : 0);
             } else {
                 client.print("ERR VAR-NOT-SUPPORTED\n");
+            }
+            return;
+        }
+        else if (subcmd == "DESC" || subcmd == "CMDDESC" || subcmd == "TYPE") {
+            String upsName;
+            String varName;
+            if (tokens.size() < 3) {
+                client.print("ERR INVALID-ARGUMENT\n");
+                return;
+            } else if (tokens.size() == 3) {
+                upsName = _config.ups_name;
+                varName = tokens[2];
+            } else {
+                upsName = tokens[2];
+                varName = tokens[3];
+            }
+
+            String upsNameLower = upsName;
+            upsNameLower.toLowerCase();
+            String configUpsNameLower = _config.ups_name;
+            configUpsNameLower.toLowerCase();
+            if (upsNameLower != configUpsNameLower) {
+                client.print("ERR UNKNOWN-UPS\n");
+                return;
+            }
+
+            if (subcmd == "TYPE") {
+                // Every variable the bridge exposes is read-only (LIST RW is
+                // empty) and goes out as a quoted string. Never answer a bare
+                // "RW": clients read the token after it as the type.
+                client.printf("TYPE %s %s STRING:64\n", upsName.c_str(), varName.c_str());
+            } else {
+                // DESC and CMDDESC share a shape. upsd answers "Unavailable"
+                // when no description database is installed; this bridge
+                // carries none for either variables or commands.
+                client.printf("%s %s %s \"Unavailable\"\n", subcmd.c_str(),
+                              upsName.c_str(), varName.c_str());
+            }
+            return;
+        }
+        else if (subcmd == "UPSDESC" || subcmd == "NUMLOGINS") {
+            String upsName;
+            if (tokens.size() < 3) {
+                upsName = _config.ups_name;
+            } else {
+                upsName = tokens[2];
+            }
+
+            String upsNameLower = upsName;
+            upsNameLower.toLowerCase();
+            String configUpsNameLower = _config.ups_name;
+            configUpsNameLower.toLowerCase();
+            if (upsNameLower != configUpsNameLower) {
+                client.print("ERR UNKNOWN-UPS\n");
+                return;
+            }
+
+            if (subcmd == "UPSDESC") {
+                client.printf("UPSDESC %s \"%s\"\n", upsName.c_str(), NUT_UPS_DESCRIPTION);
+            } else {
+                // This bridge exposes telemetry only; it tracks no upsmon LOGIN
+                // sessions, so the count of logged-in clients is always zero.
+                client.printf("NUMLOGINS %s 0\n", upsName.c_str());
             }
             return;
         }

--- a/test/test_nut_server/test_main.cpp
+++ b/test/test_nut_server/test_main.cpp
@@ -2,6 +2,7 @@
 #include "NUTServer.h"
 #include "IUSBHostUPS.h"
 #include <sstream>
+#include <algorithm>
 
 // Mock per catturare l'output di Print
 class MemoryPrinter : public Print {
@@ -235,6 +236,131 @@ void test_instcmd_beeper(void) {
 }
 
 #ifdef PIO_UNIT_TESTING
+void test_list_client_terminates(void) {
+    // LIST CLIENT must be answered with a BEGIN/END pair. A bare "ERR" is what
+    // breaks go.nut: it treats every "LIST " command as multi-line and only ends
+    // its read loop on "END LIST ...", so a single error line blocks the client
+    // until i/o timeout instead of failing fast.
+    server.processCommand(printer, 0, "LIST CLIENT testups");
+    TEST_ASSERT_EQUAL_STRING("BEGIN LIST CLIENT testups\nEND LIST CLIENT testups\n",
+                             printer.getOutput().c_str());
+
+    // Unknown UPS names still fall through to the shared handler, not an error.
+    printer.clear();
+    server.processCommand(printer, 0, "LIST CLIENT");
+    TEST_ASSERT_EQUAL_STRING("BEGIN LIST CLIENT testups\nEND LIST CLIENT testups\n",
+                             printer.getOutput().c_str());
+}
+
+void test_list_cmd_unaffected_by_client(void) {
+    // Regression: CLIENT shares a branch with CMD/RW, so the beeper listing must
+    // stay behind the CMD guard and must not leak into CLIENT.
+    mockHost.data.has.beeperEnabled = true;
+
+    printer.clear();
+    server.processCommand(printer, 0, "LIST CMD testups");
+    std::string cmdOut = printer.getOutput();
+    TEST_ASSERT_TRUE(cmdOut.find("BEGIN LIST CMD testups\n") != std::string::npos);
+    TEST_ASSERT_TRUE(cmdOut.find("CMD testups beeper.enable\n") != std::string::npos);
+    TEST_ASSERT_TRUE(cmdOut.find("END LIST CMD testups\n") != std::string::npos);
+
+    printer.clear();
+    server.processCommand(printer, 0, "LIST CLIENT testups");
+    TEST_ASSERT_TRUE(printer.getOutput().find("beeper") == std::string::npos);
+}
+
+void test_get_upsdesc_and_numlogins(void) {
+    server.processCommand(printer, 0, "GET UPSDESC testups");
+    TEST_ASSERT_EQUAL_STRING("UPSDESC testups \"ESP32-S3 UPS Bridge\"\n",
+                             printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET NUMLOGINS testups");
+    TEST_ASSERT_EQUAL_STRING("NUMLOGINS testups 0\n", printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET UPSDESC wrongups");
+    TEST_ASSERT_EQUAL_STRING("ERR UNKNOWN-UPS\n", printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET NUMLOGINS wrongups");
+    TEST_ASSERT_EQUAL_STRING("ERR UNKNOWN-UPS\n", printer.getOutput().c_str());
+}
+
+void test_get_desc_and_type(void) {
+    server.processCommand(printer, 0, "GET DESC testups ups.status");
+    TEST_ASSERT_EQUAL_STRING("DESC testups ups.status \"Unavailable\"\n",
+                             printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET TYPE testups ups.status");
+    std::string typeOut = printer.getOutput();
+    TEST_ASSERT_EQUAL_STRING("TYPE testups ups.status STRING:64\n", typeOut.c_str());
+    // Clients read the token after "RW" as the type, so a bare RW would crash
+    // them. Nothing this bridge exposes is writeable.
+    TEST_ASSERT_TRUE(typeOut.find("RW") == std::string::npos);
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET CMDDESC testups beeper.enable");
+    TEST_ASSERT_EQUAL_STRING("CMDDESC testups beeper.enable \"Unavailable\"\n",
+                             printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET DESC wrongups ups.status");
+    TEST_ASSERT_EQUAL_STRING("ERR UNKNOWN-UPS\n", printer.getOutput().c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "GET TYPE");
+    TEST_ASSERT_EQUAL_STRING("ERR INVALID-ARGUMENT\n", printer.getOutput().c_str());
+}
+
+void test_ver_and_netver(void) {
+    // go.nut sends both on every connect. It discards their errors, so these
+    // were never fatal -- but answering them keeps client.Version and
+    // client.ProtocolVersion meaningful instead of empty.
+    server.processCommand(printer, 0, "VER");
+    std::string ver = printer.getOutput();
+    TEST_ASSERT_EQUAL_STRING("Network UPS Tools esp32-nut dev\n", ver.c_str());
+
+    printer.clear();
+    server.processCommand(printer, 0, "NETVER");
+    TEST_ASSERT_EQUAL_STRING("1.3\n", printer.getOutput().c_str());
+
+    // Both must answer on a single line: go.nut reads exactly one line for a
+    // command that is not a LIST.
+    TEST_ASSERT_EQUAL(1, (int)std::count(ver.begin(), ver.end(), '\n'));
+}
+
+void test_gonut_newups_sequence(void) {
+    // go.nut's NewUPS() issues exactly these five commands, in this order, and
+    // aborts on the first failure. nut_exporter reaches LIST VAR only if every
+    // earlier call succeeds, so the whole sequence is the acceptance condition.
+    mockHost.data.has.beeperEnabled = true;
+    mockHost.data.has.batteryVoltage = true;
+    mockHost.data.batteryVoltage = 13.6f;
+
+    const char* sequence[] = {
+        "LIST CLIENT testups",
+        "LIST CMD testups",
+        "GET UPSDESC testups",
+        "GET NUMLOGINS testups",
+        "LIST VAR testups",
+        // GetVariables() then asks these two for every variable it just listed.
+        "GET DESC testups battery.voltage",
+        "GET TYPE testups battery.voltage",
+        // GetCommands() likewise asks for a description of every command.
+        "GET CMDDESC testups beeper.enable",
+    };
+
+    for (unsigned i = 0; i < sizeof(sequence) / sizeof(sequence[0]); i++) {
+        printer.clear();
+        server.processCommand(printer, 0, sequence[i]);
+        std::string out = printer.getOutput();
+        TEST_ASSERT_TRUE_MESSAGE(out.size() > 0, sequence[i]);
+        TEST_ASSERT_TRUE_MESSAGE(out.find("ERR ") == std::string::npos, sequence[i]);
+    }
+}
+
 #ifndef ARDUINO
 int main(int argc, char **argv) {
     UNITY_BEGIN();
@@ -243,6 +369,12 @@ int main(int argc, char **argv) {
     RUN_TEST(test_list_ups);
     RUN_TEST(test_get_var_compliance);
     RUN_TEST(test_instcmd_beeper);
+    RUN_TEST(test_list_client_terminates);
+    RUN_TEST(test_list_cmd_unaffected_by_client);
+    RUN_TEST(test_get_upsdesc_and_numlogins);
+    RUN_TEST(test_get_desc_and_type);
+    RUN_TEST(test_ver_and_netver);
+    RUN_TEST(test_gonut_newups_sequence);
     return UNITY_END();
 }
 #else
@@ -253,6 +385,12 @@ void setup() {
     RUN_TEST(test_list_ups);
     RUN_TEST(test_get_var_compliance);
     RUN_TEST(test_instcmd_beeper);
+    RUN_TEST(test_list_client_terminates);
+    RUN_TEST(test_list_cmd_unaffected_by_client);
+    RUN_TEST(test_get_upsdesc_and_numlogins);
+    RUN_TEST(test_get_desc_and_type);
+    RUN_TEST(test_ver_and_netver);
+    RUN_TEST(test_gonut_newups_sequence);
     UNITY_END();
 }
 void loop() {}


### PR DESCRIPTION
## Problem

The NUT server leaves eight commands unimplemented. Six of them break clients built on [`go.nut`](https://github.com/robbiet480/go.nut) — including [`DRuggeri/nut_exporter`](https://github.com/DRuggeri/nut_exporter), the common Prometheus path — and one also breaks description lookup in [`aionut`](https://github.com/bdraco/aionut), the client Home Assistant's NUT integration uses.

Scraping a v1.4.0 bridge with `nut_exporter` fails like this:

```
HTTP 500 in 2.27s
error collecting metric ... "Failure instantiating the UPS":
  error reading response: read tcp 192.168.1.66:48532->192.168.0.194:3493: i/o timeout
```

## Root cause

`go.nut`'s `NewUPS()` calls five methods in order and aborts on the first failure, so it never reaches the variable list. Tracing every method it invokes — including what `GetVariables()` and `GetCommands()` do internally, which is where most of the gap hides:

| go.nut call | NUT command(s) | v1.4.0 |
|---|---|---|
| `Connect` | `VER`, `NETVER` | missing (errors discarded, non-fatal) |
| `GetUPSList` | `LIST UPS` | ok |
| `GetClients` | `LIST CLIENT` | **missing** |
| `GetCommands` | `LIST CMD` + `GET CMDDESC` per command | `CMDDESC` **missing** |
| `GetDescription` | `GET UPSDESC` | **missing** |
| `GetNumberOfLogins` | `GET NUMLOGINS` | **missing** |
| `GetVariables` | `LIST VAR` + `GET DESC`, `GET TYPE` per variable | `DESC`, `TYPE` **missing** |
| `Disconnect` | `LOGOUT` | ok |

`LIST CLIENT` is the damaging one, and it explains why the symptom is a **hang** rather than a clean error. `go.nut` treats any command starting `LIST ` as multi-line and ends its read loop only on the exact `END LIST …` string:

```go
endLine := fmt.Sprintf("END %s", cmd)
resp, err = c.ReadResponse(endLine, strings.HasPrefix(cmd, "LIST "))
```

A single `ERR UNKNOWN-COMMAND` line never matches, so the client blocks until i/o timeout. Real `upsd` implements `LIST CLIENT`, so the durable fix belongs here — but that client fragility is why one missing command takes out the whole scrape.

## Changes

`LIST CLIENT` joins the existing `CMD`/`RW` branch. That branch already emits a generic `BEGIN`/`END LIST <subcmd> <ups>` pair and keeps the beeper listing behind a `subcmd == "CMD"` guard, so an empty client list needs nothing more than admitting the subcommand.

`GET UPSDESC`, `GET NUMLOGINS`, `GET DESC`, `GET TYPE`, and `GET CMDDESC` are new branches in the `GET` handler, reusing the UPS-name match from `GET VAR` so a wrong name still returns `ERR UNKNOWN-UPS`.

`VER` and `NETVER` answer single lines. `VER` reports `FIRMWARE_VERSION`, injected from the release tag the same way `src/network/web_config_server.cpp` does it.

**No previously-successful response changes** — the patch only turns errors into data.

## Judgment calls worth reviewing

- **`DESC` / `CMDDESC` answer `"Unavailable"`**, which is what `upsd` returns when no description database is installed. The bridge carries none for either variables or commands.
- **`TYPE` answers `STRING:64`** for every variable. Everything the bridge exposes is read-only (`LIST RW` is empty) and goes out quoted. It deliberately never answers a bare `RW`: clients read the token *after* `RW` as the type, so a bare `RW` would crash them. A real per-variable type table would be a reasonable follow-up.
- **`NUMLOGINS` is always 0** — the bridge is telemetry-only and tracks no `upsmon` LOGIN sessions.
- **`NETVER` reports `1.3`**, the protocol level the implemented subset targets, as `upsd` reports it.
- **The UPS description literal is hoisted to a constant** so `LIST UPS` and `GET UPSDESC` cannot drift. That's the only line touched that isn't strictly the fix.
- `DESC`/`TYPE`/`CMDDESC` answer for any name rather than validating against the known variable set, which keeps the patch small. The only caller asks about items it just enumerated.
- `HELP` and `SET` remain unimplemented — no client on this path calls them.

## Tests

`test/test_nut_server/test_main.cpp` gains 6 cases (5 → 11; full native suite 52 → 58). `test_gonut_newups_sequence` walks the entire `NewUPS()` command sequence in order and asserts none returns `ERR`, which is the actual condition `nut_exporter` needs — the per-command assertions alone would not have caught `GET CMDDESC`.

```
native  test_nut_server  PASSED    11 test cases
        full suite       PASSED    58 test cases
```

## Hardware verification

Built and flashed over OTA to an ESP32-S3 bridge on a CyberPower CP1500PFCLCDa.

`nut_exporter`, same request before and after:

```
BEFORE   HTTP 500 in 2.27s   i/o timeout
AFTER    HTTP 200 in 1.21s   28 series
```

Replaying `aionut`'s exact command pattern from a Home Assistant host, patched bridge vs. an unpatched v1.4.0 bridge:

| | patched | v1.4.0 |
|---|---|---|
| `LIST UPS` | PASS | PASS |
| `LIST VAR` | PASS (18 vars) | PASS (18 vars) |
| `LIST CMD` | PASS (3 cmds) | PASS (3 cmds) |
| `GET UPSDESC` | **PASS** | **FAIL** `ERR INVALID-ARGUMENT` |

`GET UPSDESC` is what `aionut`'s `description()` calls, so Home Assistant users gain a fix here rather than risking a regression.

Also verified directly on the device:

```
VER                       -> Network UPS Tools esp32-nut dev
NETVER                    -> 1.3
LIST CLIENT Desk          -> BEGIN LIST CLIENT Desk / END LIST CLIENT Desk
GET UPSDESC Desk          -> UPSDESC Desk "ESP32-S3 UPS Bridge"
GET NUMLOGINS Desk        -> NUMLOGINS Desk 0
GET DESC Desk ups.status  -> DESC Desk ups.status "Unavailable"
GET TYPE Desk ups.status  -> TYPE Desk ups.status STRING:64
GET CMDDESC Desk beeper.enable -> CMDDESC Desk beeper.enable "Unavailable"
LIST CMD Desk             -> unchanged, still lists the three beeper commands
```

(`VER` shows `dev` because this was a local build; a release build reports the tag.)
